### PR TITLE
Use a data attribute for portlethash

### DIFF
--- a/collective/portletpage/browser/portletpage-column.pt
+++ b/collective/portletpage/browser/portletpage-column.pt
@@ -1,7 +1,8 @@
 <tal:block repeat="portlet options/portlets">
 <div tal:attributes="id python:view.portlet_id(portlet)">
     <div tal:attributes="id string:portletwrapper-${portlet/hash};
-                         class string:portletWrapper kssattr-portlethash-${portlet/hash};"
+                         class string:portletWrapper kssattr-portlethash-${portlet/hash};
+                         data-portlethash ${portlet/hash};"
          tal:content="structure python:view.safe_render(portlet['renderer'])" />
 </div>
 </tal:block>

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,8 +4,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Add a data-portlethash attribute to be compliant wit
+  Plone 4.3 behavior
+  [ale-rt]
 
 1.2.1 (2014-10-29)
 ------------------


### PR DESCRIPTION
Plone 4.3 relies on a `data-portlethash` attribute instead of the old `kssClasskssattr-portlethash-${portlet/hash}`:

- https://github.com/plone/Products.CMFPlone/blob/4.3/Products/CMFPlone/skins/plone_ecmascript/kss-bbb.js

Without this patch trying to switch month on a calendar portlet embedded in a portlet page will fail.
In the log you will read:
```
2015-07-06 09:38:17 ERROR Zope.SiteErrorLog 1436168297.070.649509621438 http://localhost:8080/Plone/homepage/@@render-portlet
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 72, in mapply
  Module ZPublisher.Publish, line 53, in missing_name
  Module ZPublisher.HTTPResponse, line 741, in badRequestError
BadRequest:   <h2>Site Error</h2>
  <p>An error was encountered while publishing this resource.
  </p>
  <p><strong>Invalid request</strong></p>

  The parameter, <em>portlethash</em>, was omitted from the request.<p>Make sure to specify all required parameters, and try the request again.</p>
  <hr noshade="noshade"/>

  <p>Troubleshooting Suggestions</p>

  <ul>
  <li>The URL may be incorrect.</li>
  <li>The parameters passed to this resource may be incorrect.</li>
  <li>A resource that this resource relies on may be
      encountering an error.</li>
  </ul>

  <p>For more detailed information about the error, please
  refer to the error log.
  </p>

  <p>If the error persists please contact the site maintainer.
  Thank you for your patience.
  </p>
```
